### PR TITLE
fix(RequestValidatorId): add support for objects

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = crlf
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = false
+
+[.md]
+indent_style = space
+indent_size = 4

--- a/README.md
+++ b/README.md
@@ -50,4 +50,55 @@ For every function you wish to use the validator set property `reqValidatorName:
           reqValidatorName: 'xMyRequestValidator'
 ```
 
+### Use Validator specified in different Stack
+The serverless framework allows us to share resources among several stacks. Therefore a CloudFormation Output has to be specified in one stack. This Output can be imported in another stack to make use of it. For more information see
+[here](https://serverless.com/framework/docs/providers/aws/guide/variables/#reference-cloudformation-outputs).
 
+Specify a request validator in a different stack:
+
+```
+plugins:
+  - serverless-reqvalidator-plugin
+service: my-service-a
+functions:
+  hello:
+    handler: handler.myHandler
+    events:
+      - http:
+          path: hello
+          reqValidatorName: 'myReqValidator'
+
+resources:
+  Resource:
+    xMyRequestValidator:
+      Type: "AWS::ApiGateway::RequestValidator"
+      Properties:
+        Name: 'my-req-validator'
+        RestApiId: 
+          Ref: ApiGatewayRestApi
+        ValidateRequestBody: true
+        ValidateRequestParameters: false
+  Outputs:
+    xMyRequestValidator:
+      Value:
+        Ref: my-req-validator
+      Export:
+        Name: myReqValidator
+
+
+```
+
+Make use of the exported request validator in stack b:
+```
+plugins:
+  - serverless-reqvalidator-plugin
+service: my-service-b
+functions:
+  hello:
+    handler: handler.myHandler
+    events:
+      - http:
+          path: hello
+          reqValidatorName:
+            Fn::ImportValue: 'myReqValidator'
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-reqvalidator-plugin",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Serverless plugin for setting request validation",
   "main": "src/index.js",
   "scripts": {
@@ -16,6 +16,9 @@
     "requestvalidator"
   ],
   "author": "RafPe < me@rafpe.ninja >",
+  "contributors": [
+    "pj035 pm.jaecks@gmail.com (http://pjaecks.de)"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/RafPe/serverless-reqvalidator-plugin/issues"


### PR DESCRIPTION
Bug: If the request validator name is specified as an object (e.g. like 'Fn::ImportValue': 'my-export-value'), then the deployment failed.

Fix: Add the RequestValidatorId dependent on the type of `reqValidatorName`, i.e. strings are added as `Ref`, whereas objects will be added as they are.

Resolves https://github.com/RafPe/serverless-reqvalidator-plugin/issues/2