### PR TITLE
Hooking before:package:finalize rather than deploy

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,7 @@ class ServerlessReqValidatorPlugin {
     this._beforeDeploy = this.beforeDeploy.bind(this)
 
     this.hooks = {
-      'before:deploy:deploy': this._beforeDeploy
+      'before:package:finalize': this._beforeDeploy
     };
 
   }


### PR DESCRIPTION
This allows compatibility with  https://github.com/dougmoscrop/serverless-plugin-split-stacks
Docs plugin has already made the changed.