### PR TITLE
Fix documentation typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ functions:
           reqValidatorName: 'myReqValidator'
 
 resources:
-  Resource:
+  Resources:
     xMyRequestValidator:
       Type: "AWS::ApiGateway::RequestValidator"
       Properties:


### PR DESCRIPTION
Hi there, this pull request is for fix a documentation typo. Current documentation isn't valid for Serverless version 1.30.3.

This PR fixes this error: **The CloudFormation template is invalid: Invalid template property or properties [Resource]**.