### PR TITLE
Change hook trigger

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,7 @@ class ServerlessReqValidatorPlugin {
     this._beforeDeploy = this.beforeDeploy.bind(this)
 
     this.hooks = {
-      'before:package:finalize': this._beforeDeploy
+      'before:deploy:deploy': this._beforeDeploy
     };
 
   }


### PR DESCRIPTION
This will allow serverless-reqvalidator-plugin to properly work with serverless-plugin-split-stacks
If reqvalidator doesn't run before split-stacks, it will throw an error since it wont be able to find the method on defined resources (they are changed by split-stacks).