### PR TITLE
[WIP] Adding support for request models

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -97,6 +97,11 @@ class ServerlessReqValidatorPlugin {
               resources[methodName].Properties.RequestValidatorId = { "Ref": `${reqValidatorName}` };
               break;
           }
+
+          const requestModels = event.http.requestModels;
+          if (requestModels) {
+            resources[methodName].Properties.RequestModels = requestModels
+          }
         }
       });
     }


### PR DESCRIPTION
I noticed that a simple addition would enable the use of native `AWS::ApiGateway::Model` objects for model validation instead of needing the dependency on `serverless-aws-documentation`.

All I had to do to add my model was:
```
  events:
    - http:
        path: "deleteEndpoint"
        method: "delete"
        authorizer: "aws_iam"
        reqValidatorName: JsonRequestValidator
        requestModels:
          application/json:
            Ref: Model
```
Where `Model` is the AWS ApiGateway Model object:
```
Model:
    Type: 'AWS::ApiGateway::Model'
    Properties:
      ContentType: application/json
      Description: Description
      Name: DeleteRequest
      RestApiId:
        Ref: ApiGatewayRestApi
      Schema:
        $schema: 'http://json-schema.org/draft-04/schema#'
        type: array
        items:
          type: object
          properties:
            sharerID:
              type: integer
              minimum: 0
            sharedWithID:
              type: integer
              minimum: 0
          additionalProperties: false
          required:
            - sharerID
            - sharedWithID
```

Let me know what you think! If it's something you'd like to add to the library, I can flesh out the documentation on using it, increment the package.json version, make the code more robust, etc.

Otherwise, I'll just used the fork I made and go on my merry way :)