### PR TITLE
make properties optional

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,6 @@ class ServerlessReqValidatorPlugin {
       properties: {
         reqValidatorName: { type: 'string' },
       },
-      required: ['reqValidatorName'],
     });
 
     this.hooks = {


### PR DESCRIPTION
Hi RafPe!

Me and my colleagues greatly appreciate your work in developing this plugin and use it in a number of services. In order to avoid warnings in deployment we would offer making the reqValidatorName property optional as we do not use it in all endpoints.

Best Regards, Konstantin Kanchev